### PR TITLE
Now supports hitting multiple paths on the same host in the same load…

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,14 +8,16 @@ import (
 )
 
 type config struct {
-	numConns                       uint64
-	numReqs                        *uint64
-	duration                       *time.Duration
-	url, method, certPath, keyPath string
-	body, bodyFilePath             string
-	stream                         bool
-	headers                        *headersList
-	timeout                        time.Duration
+	numConns                  uint64
+	numReqs                   *uint64
+	duration                  *time.Duration
+	method, certPath, keyPath string
+	baseUrl                   string
+	paths                     []string
+	body, bodyFilePath        string
+	stream                    bool
+	headers                   *headersList
+	timeout                   time.Duration
 	// TODO(codesenberg): printLatencies should probably be
 	// re(named&maked) into printPercentiles or even let
 	// users provide their own percentiles and not just
@@ -83,14 +85,14 @@ func (c *config) testType() testTyp {
 }
 
 func (c *config) checkURL() error {
-	url, err := url.Parse(c.url)
+	url, err := url.Parse(c.baseUrl)
 	if err != nil {
 		return err
 	}
 	if url.Host == "" || (url.Scheme != "http" && url.Scheme != "https") {
 		return errInvalidURL
 	}
-	c.url = url.String()
+	c.baseUrl = url.String()
 	return nil
 }
 


### PR DESCRIPTION
I doubt this is a feature you want on the master branch (especially because reporting will aggregate the totals from _all_ paths specified instead of each path individually, _and_ the fact that requests will be doubled or trebled in a non-intuitive way because this mechanism subverts the request limiting flags on the command line), however the ability to hit multiple paths on the same host is incredibly useful to simulate real-world load scenarios, and I haven't been able to find a golang tool with this capability.