### PR TITLE
Add new flag 'randid'

### DIFF
--- a/args_parser.go
+++ b/args_parser.go
@@ -37,6 +37,7 @@ type kingpinParser struct {
 	keyPath      string
 	rate         *nullableUint64
 	clientType   clientTyp
+	randID       bool
 
 	printSpec *nullableString
 	noPrint   bool
@@ -108,6 +109,10 @@ func newKingpinParser() argsParser {
 			" chain and host name").
 		Short('k').
 		BoolVar(&kparser.insecure)
+	app.Flag("randid",
+		"Controls if the string '<[_id]>' should be replaced with a"+
+			" random value in the body").
+		BoolVar(&kparser.randID)
 
 	app.Flag("header", "HTTP headers to use(can be repeated)").
 		PlaceHolder("\"K: V\"").
@@ -224,6 +229,7 @@ func (k *kingpinParser) parse(args []string) (config, error) {
 		insecure:       k.insecure,
 		rate:           k.rate.val,
 		clientType:     k.clientType,
+		randID:         k.randID,
 		printIntro:     pi,
 		printProgress:  pp,
 		printResult:    pr,

--- a/bombardier.go
+++ b/bombardier.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,11 +14,12 @@ import (
 	"time"
 
 	"github.com/codesenberg/bombardier/internal"
+	"github.com/valyala/fastrand"
 
 	"github.com/cheggaaa/pb"
 	fhist "github.com/codesenberg/concurrent/float64/histogram"
 	uhist "github.com/codesenberg/concurrent/uint64/histogram"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type bombardier struct {
@@ -248,6 +250,12 @@ func (b *bombardier) writeStatistics(
 }
 
 func (b *bombardier) performSingleRequest() {
+	// prepare body if needed
+	if b.conf.randID {
+		b.conf.body = strings.ReplaceAll(b.conf.body, "<[_id]>",
+			strconv.FormatUint(uint64(fastrand.Uint32()), 10))
+	}
+
 	code, msTaken, err := b.client.do()
 	if err != nil {
 		b.errors.add(err)

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type config struct {
 	numConns                       uint64
 	numReqs                        *uint64
 	duration                       *time.Duration
+	randID                         bool
 	url, method, certPath, keyPath string
 	body, bodyFilePath             string
 	stream                         bool


### PR DESCRIPTION
This PR adds a new flag named `randid`, when it's enabled it replaces `<[_id]>` with a random uint32 in the request body.

This means the following body:
```json
{"name":"new_new_new<[_id]>","email":"verynice@very.com","password":"not_so_good"}
```

will be replaced (for example) with the following content – if `randid` is enabled:
```json
{"name":"new_new_new23154","email":"verynice@very.com","password":"not_so_good"}
```

To decrease the "random number generation time" I use [fastrand](https://github.com/valyala/fastrand), on my PC it was _94 %_ faster than the normal `math.rand` function.

Raw benchmark results on my PC:
```
goos: linux
goarch: amd64
pkg: github.com/valyala/fastrand
BenchmarkUint32n-2                     	100000000	        10.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkRNGUint32n-2                  	653525556	         1.84 ns/op	       0 B/op	       0 allocs/op
BenchmarkRNGUint32nWithLock-2          	34382449	        31.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkRNGUint32nArray-2             	50329755	        59.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkMathRandInt31n-2              	27102625	        43.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkMathRandRNGInt31n-2           	259698030	         4.62 ns/op	       0 B/op	       0 allocs/op
BenchmarkMathRandRNGInt31nWithLock-2   	34518178	        39.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkMathRandRNGInt31nArray-2      	 6467250	       184 ns/op	       0 B/op	       0 allocs/op
```

----

Since in #55 was discussed to implement another flag where the place holder values will be read from a file I'm unsure if this PR covers the complete requested feature of #55.

But since I'm also needed a possibility to have a "placeholder var" in the body I implemented this one with "random ID's".
