### PR TITLE
fix: correct some namings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 cover.*
+bombardier

--- a/bombardier.go
+++ b/bombardier.go
@@ -34,7 +34,7 @@ type bombardier struct {
 	conf        config
 	barrier     completionBarrier
 	ratelimiter limiter
-	workers     sync.WaitGroup
+	wg          sync.WaitGroup
 
 	timeTaken time.Duration
 	latencies *uhist.Histogram
@@ -152,7 +152,7 @@ func newBombardier(c config) (*bombardier, error) {
 		return nil, err
 	}
 
-	b.workers.Add(int(c.numConns))
+	b.wg.Add(int(c.numConns))
 	b.errors = newErrorMap()
 	b.doneChan = make(chan struct{}, 2)
 	return b, nil
@@ -223,9 +223,9 @@ func (b *bombardier) prepareTemplate() (*template.Template, error) {
 }
 
 func (b *bombardier) writeStatistics(
-	code int, msTaken uint64,
+	code int, usTaken uint64,
 ) {
-	b.latencies.Increment(msTaken)
+	b.latencies.Increment(usTaken)
 	b.rpl.Lock()
 	b.reqs++
 	b.rpl.Unlock()
@@ -248,11 +248,11 @@ func (b *bombardier) writeStatistics(
 }
 
 func (b *bombardier) performSingleRequest() {
-	code, msTaken, err := b.client.do()
+	code, usTaken, err := b.client.do()
 	if err != nil {
 		b.errors.add(err)
 	}
-	b.writeStatistics(code, msTaken)
+	b.writeStatistics(code, usTaken)
 }
 
 func (b *bombardier) worker() {
@@ -296,15 +296,14 @@ func (b *bombardier) rateMeter() {
 	requestsInterval += 10 * time.Millisecond
 	ticker := time.NewTicker(requestsInterval)
 	defer ticker.Stop()
-	tick := ticker.C
 	done := b.barrier.done()
 	for {
 		select {
-		case <-tick:
+		case <-ticker.C:
 			b.recordRps()
 			continue
 		case <-done:
-			b.workers.Wait()
+			b.wg.Wait()
 			b.recordRps()
 			b.doneChan <- struct{}{}
 			return
@@ -333,13 +332,13 @@ func (b *bombardier) bombard() {
 	b.start = time.Now()
 	for i := uint64(0); i < b.conf.numConns; i++ {
 		go func() {
-			defer b.workers.Done()
+			defer b.wg.Done()
 			b.worker()
 		}()
 	}
 	go b.rateMeter()
 	go b.barUpdater()
-	b.workers.Wait()
+	b.wg.Wait()
 	b.timeTaken = time.Since(bombardmentBegin)
 	<-b.doneChan
 	<-b.doneChan

--- a/clients.go
+++ b/clients.go
@@ -14,7 +14,7 @@ import (
 )
 
 type client interface {
-	do() (code int, msTaken uint64, err error)
+	do() (code int, usTaken uint64, err error)
 }
 
 type bodyStreamProducer func() (io.ReadCloser, error)
@@ -73,7 +73,7 @@ func newFastHTTPClient(opts *clientOpts) client {
 }
 
 func (c *fasthttpClient) do() (
-	code int, msTaken uint64, err error,
+	code int, usTaken uint64, err error,
 ) {
 	// prepare the request
 	req := fasthttp.AcquireRequest()
@@ -104,7 +104,7 @@ func (c *fasthttpClient) do() (
 	} else {
 		code = resp.StatusCode()
 	}
-	msTaken = uint64(time.Since(start).Nanoseconds() / 1000)
+	usTaken = uint64(time.Since(start).Nanoseconds() / 1000)
 
 	// release resources
 	fasthttp.ReleaseRequest(req)
@@ -161,7 +161,7 @@ func newHTTPClient(opts *clientOpts) client {
 }
 
 func (c *httpClient) do() (
-	code int, msTaken uint64, err error,
+	code int, usTaken uint64, err error,
 ) {
 	req := &http.Request{}
 
@@ -201,7 +201,7 @@ func (c *httpClient) do() (
 			err = cerr
 		}
 	}
-	msTaken = uint64(time.Since(start).Nanoseconds() / 1000)
+	usTaken = uint64(time.Since(start).Nanoseconds() / 1000)
 
 	return
 }


### PR DESCRIPTION
`msTaken` seems to be the meaning of `usTaken` since it's obtained by `nanoseconds()/1000`

Another one, WaitGroup variable is often called `wg`. The name `workers` seems to collide with function `worker()`