### PR TITLE
Adding simple verbose flag and output.

### DIFF
--- a/cmd/utils/simplebenchserver/doc.go
+++ b/cmd/utils/simplebenchserver/doc.go
@@ -6,5 +6,6 @@ Following options are available:
                      --help-man).
   -p, --port="8080"  port to use for benchmarks
   -s, --size=1024    size of response in bytes
+      --verbose      print the incoming requests
 */
 package main

--- a/cmd/utils/simplebenchserver/main.go
+++ b/cmd/utils/simplebenchserver/main.go
@@ -17,6 +17,9 @@ var responseSize = kingpin.Flag("size", "size of response in bytes").
 	Short('s').
 	Uint()
 
+var verboseOutput = kingpin.Flag("verbose", "print the incoming requests").
+	Bool()
+
 func main() {
 	kingpin.Parse()
 	response := strings.Repeat("a", int(*responseSize))
@@ -27,6 +30,11 @@ func main() {
 		if werr != nil {
 			log.Println(werr)
 		}
+
+		if *verboseOutput {
+			log.Printf("Data from %s, size: %d\n", addr, *responseSize)
+		}
+
 	})
 	if err != nil {
 		log.Println(err)

--- a/cmd/utils/simplebenchserver/main.go
+++ b/cmd/utils/simplebenchserver/main.go
@@ -32,7 +32,7 @@ func main() {
 		}
 
 		if *verboseOutput {
-			log.Printf("Data from %s, size: %d\n", addr, *responseSize)
+			log.Printf("Data received on: %s, size: %d\n", addr, *responseSize)
 		}
 
 	})


### PR DESCRIPTION
`cmd/utils/simplebenchmarkserver`: Adding simple verbose output flag to show incoming requests.

Verbose flags to show incoming requests, possible to help those who are unsure whether the data is being properly sent to `localhost:port`.
