### PR TITLE
Add latencies for 2xx responses

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/klauspost/compress v1.11.8 h1:difgzQsp5mdAz9v8lm3P/I+EpDKMU/6uTMw1y1F
 github.com/klauspost/compress v1.11.8/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -38,6 +39,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
@@ -46,8 +48,10 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.21.0 h1:fJjaQ7cXdaSF9vDBujlHLDGj7AgoMTMIXvICeePzYbU=
 github.com/valyala/fasthttp v1.21.0/go.mod h1:jjraHZVbKOXftJfsOYoAjaeygpj5hr8ermTRJNroD7A=
+github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a h1:0R4NLDRDZX6JcmhJgXi5E4b8Wg84ihbmUKp/GvSPEzc=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 h1:5kGOVHlq0euqwzgTC9Vu15p6fV1Wi0ArVi8da2urnVg=
@@ -61,10 +65,12 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/histogram_aggregates_float64.go
+++ b/internal/histogram_aggregates_float64.go
@@ -1,0 +1,80 @@
+package internal
+
+import (
+	"errors"
+	"math"
+	"sort"
+)
+
+// ReadonlyFloat64Histogram is a readonly histogram with float64 keys
+type ReadonlyFloat64Histogram interface {
+	Get(float64) uint64
+	VisitAll(func(float64, uint64) bool)
+	Count() uint64
+}
+
+// float64Aggregates holds aggregates calculated from float64 histograms
+type float64Aggregates struct {
+	Sum   float64
+	Count uint64
+	Max   float64
+	Pairs []struct {
+		k float64
+		v uint64
+	}
+}
+
+// NewFloat64HistogramAggregates calculates aggregates from a ReadonlyFloat64Histogram
+func NewFloat64HistogramAggregates(histogram ReadonlyFloat64Histogram) (*float64Aggregates, error) {
+	aggregates := new(float64Aggregates)
+	aggregates.Pairs = make([]struct {
+		k float64
+		v uint64
+	}, 0, histogram.Count())
+	histogram.VisitAll(func(f float64, c uint64) bool {
+		if math.IsInf(f, 0) || math.IsNaN(f) {
+			return true
+		}
+		if f > aggregates.Max {
+			aggregates.Max = f
+		}
+		aggregates.Sum += f * float64(c)
+		aggregates.Count += c
+		aggregates.Pairs = append(aggregates.Pairs, struct {
+			k float64
+			v uint64
+		}{f, c})
+		return true
+	})
+	if aggregates.Count < 1 {
+		return nil, errors.New("Not enough values")
+	}
+	sort.Slice(aggregates.Pairs, func(i, j int) bool {
+		return aggregates.Pairs[i].k < aggregates.Pairs[j].k
+	})
+	return aggregates, nil
+}
+
+// percentilesMap gives the values for a list of percentiles given as input
+func (a *float64Aggregates) percentilesMap(percentiles []float64) map[float64]float64 {
+	percentilesMap := map[float64]float64{}
+	for _, pc := range percentiles {
+		if _, calculated := percentilesMap[pc]; calculated {
+			continue
+		}
+		if pc < 0 || pc > 1 {
+			// Drop percentiles outside of [0, 1] range
+			continue
+		}
+		rank := uint64(pc*float64(a.Count) + 0.5)
+		total := uint64(0)
+		for _, p := range a.Pairs {
+			total += p.v
+			if total >= rank {
+				percentilesMap[pc] = p.k
+				break
+			}
+		}
+	}
+	return percentilesMap
+}

--- a/internal/histogram_aggregates_uint64.go
+++ b/internal/histogram_aggregates_uint64.go
@@ -1,0 +1,73 @@
+package internal
+
+import (
+	"errors"
+	"sort"
+)
+
+// ReadonlyUint64Histogram is a readonly histogram with uint64 keys
+type ReadonlyUint64Histogram interface {
+	Get(uint64) uint64
+	VisitAll(func(uint64, uint64) bool)
+	Count() uint64
+}
+
+// uint64Aggregates holds aggregates calculated from uint64 histograms
+type uint64Aggregates struct {
+	Sum   uint64
+	Count uint64
+	Max   uint64
+	Pairs []struct {
+		k uint64
+		v uint64
+	}
+}
+
+// NewUint64HistogramAggregates calculates aggregates from a ReadonlyUint64Histogram
+func NewUint64HistogramAggregates(histogram ReadonlyUint64Histogram) (*uint64Aggregates, error) {
+	aggregates := new(uint64Aggregates)
+	aggregates.Pairs = make([]struct {
+		k uint64
+		v uint64
+	}, 0, histogram.Count())
+	histogram.VisitAll(func(f uint64, c uint64) bool {
+		if f > aggregates.Max {
+			aggregates.Max = f
+		}
+		aggregates.Sum += f * c
+		aggregates.Count += c
+		aggregates.Pairs = append(aggregates.Pairs, struct{ k, v uint64 }{f, c})
+		return true
+	})
+	if aggregates.Count < 1 {
+		return nil, errors.New("Not enough values")
+	}
+	sort.Slice(aggregates.Pairs, func(i, j int) bool {
+		return aggregates.Pairs[i].k < aggregates.Pairs[j].k
+	})
+	return aggregates, nil
+}
+
+// percentilesMap gives the values for a list of percentiles given as input
+func (a *uint64Aggregates) percentilesMap(percentiles []float64) map[float64]uint64 {
+	percentilesMap := map[float64]uint64{}
+	for _, pc := range percentiles {
+		if _, calculated := percentilesMap[pc]; calculated {
+			continue
+		}
+		if pc < 0 || pc > 1 {
+			// Drop percentiles outside of [0, 1] range
+			continue
+		}
+		rank := uint64(pc*float64(a.Count) + 0.5)
+		total := uint64(0)
+		for _, p := range a.Pairs {
+			total += p.v
+			if total >= rank {
+				percentilesMap[pc] = p.k
+				break
+			}
+		}
+	}
+	return percentilesMap
+}

--- a/templates.go
+++ b/templates.go
@@ -45,8 +45,12 @@ const (
 {{ with .Result.LatenciesStats (FloatsToArray 0.5 0.75 0.9 0.95 0.99) }}
 	{{- printf "  %-10v %10v %10v %10v" "Latency" (FormatTimeUs .Mean) (FormatTimeUs .Stddev) (FormatTimeUs .Max) }}
 	{{- if WithLatencies }}
-  		{{- "\n  Latency Distribution" }}
+  		{{- "\n  Latency Distribution (Total)" }}
 		{{- range $pc, $lat := .Percentiles }}
+			{{- printf "\n     %2.0f%% %10s" (Multiply $pc 100) (FormatTimeUsUint64 $lat) -}}
+		{{ end -}}
+		{{- "\n  Latency Distribution (2xx)" }}
+		{{- range $pc, $lat := .Percentiles2xx }}
 			{{- printf "\n     %2.0f%% %10s" (Multiply $pc 100) (FormatTimeUsUint64 $lat) -}}
 		{{ end -}}
 	{{ end }}
@@ -146,6 +150,12 @@ const (
 {{- if WithLatencies -}}
 ,"percentiles":{
 {{- range $pc, $lat := .Percentiles }}
+{{- if ne $pc 0.5 -}},{{- end -}}
+{{- printf "\"%2.0f\":%d" (Multiply $pc 100) $lat -}}
+{{- end -}}
+},
+"percentiles2xx":{
+{{- range $pc, $lat := .Percentiles2xx }}
 {{- if ne $pc 0.5 -}},{{- end -}}
 {{- printf "\"%2.0f\":%d" (Multiply $pc 100) $lat -}}
 {{- end -}}

--- a/templates.go
+++ b/templates.go
@@ -49,9 +49,11 @@ const (
 		{{- range $pc, $lat := .Percentiles }}
 			{{- printf "\n     %2.0f%% %10s" (Multiply $pc 100) (FormatTimeUsUint64 $lat) -}}
 		{{ end -}}
-		{{- "\n  Latency Distribution (2xx)" }}
-		{{- range $pc, $lat := .Percentiles2xx }}
-			{{- printf "\n     %2.0f%% %10s" (Multiply $pc 100) (FormatTimeUsUint64 $lat) -}}
+		{{- if .Percentiles2xx }}
+			{{- "\n  Latency Distribution (2xx)" }}
+			{{- range $pc, $lat := .Percentiles2xx }}
+				{{- printf "\n     %2.0f%% %10s" (Multiply $pc 100) (FormatTimeUsUint64 $lat) -}}
+			{{ end -}}
 		{{ end -}}
 	{{ end }}
 {{ else }}


### PR DESCRIPTION
In cases where a service returns a lot of error codes it was impossible to know the response times of the successful operations. Now an additional histogram value collection for 2xx responses was added.

Before:
```
Statistics        Avg      Stdev        Max
  Reqs/sec      2195.55     302.63    2600.64
  Latency        3.67ms    30.53ms      1.02s
  Latency Distribution
     50%     2.90ms
     75%     3.04ms
     90%     3.28ms
     95%     3.63ms
     99%     5.45ms
  HTTP codes:
    1xx - 0, 2xx - 11, 3xx - 0, 4xx - 0, 5xx - 11009
    others - 0
  Throughput:   513.10KB/s
```

After:
```
Statistics        Avg      Stdev        Max
  Reqs/sec      1947.65     558.64    2566.71
  Latency        4.13ms    32.36ms      1.01s
  Latency Distribution (Total)
     50%     2.91ms
     75%     3.18ms
     90%     4.08ms
     95%     4.96ms
     99%    10.69ms
  Latency Distribution (2xx)
     50%      1.00s
     75%      1.00s
     90%      1.01s
     95%      1.01s
     99%      1.01s
  HTTP codes:
    1xx - 0, 2xx - 11, 3xx - 0, 4xx - 0, 5xx - 9785
    others - 0
  Throughput:   456.62KB/s
```

In case of no 2xx the result is omitted:
```
Statistics        Avg      Stdev        Max
  Reqs/sec      2052.87     469.71    2646.66
  Latency        3.89ms     1.43ms    29.66ms
  Latency Distribution (Total)
     50%     3.69ms
     75%     4.16ms
     90%     5.34ms
     95%     6.36ms
     99%     9.31ms
  HTTP codes:
    1xx - 0, 2xx - 0, 3xx - 0, 4xx - 10271, 5xx - 0
    others - 0
  Throughput:   659.54KB/s
```

The json output now looks like this:
```json
{
  "spec": {
    "numberOfConnections": 4,
    "testType": "timed",
    "testDurationSeconds": 2,
    "method": "GET",
    "url": "http://localhost:8088/calculate-limited?argument=abc",
    "body": "",
    "stream": false,
    "timeoutSeconds": 1,
    "client": "fasthttp"
  },
  "result": {
    "bytesRead": 596028,
    "bytesWritten": 320988,
    "timeTakenSeconds": 3.512297515,
    "req1xx": 0,
    "req2xx": 3,
    "req3xx": 0,
    "req4xx": 0,
    "req5xx": 3482,
    "others": 0,
    "latency": {
      "mean": 2868.1977044476325,
      "stddev": 52273.760421009916,
      "max": 2505392,
      "percentiles": {
        "50": 1049,
        "75": 1169,
        "90": 1582,
        "95": 1907,
        "99": 2979
      },
      "percentiles2xx": {
        "50": 997482,
        "75": 997482,
        "90": 2505392,
        "95": 2505392,
        "99": 2505392
      }
    },
    "rps": {
      "mean": 1720.3570087831786,
      "stddev": 453.862925891273,
      "max": 2305.700383057032,
      "percentiles": {
        "50": 1773.912226,
        "75": 2167.367572,
        "90": 2259.393315,
        "95": 2276.839843,
        "99": 2289.22986
      }
    }
  }
}
```

If there are no 2xx responses the new json attribute is empty: `"percentiles2xx": {}`