### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tested on go1.8 and higher.
 You can grab binaries in the [releases](https://github.com/codesenberg/bombardier/releases) section.
 Alternatively, to get latest and greatest run:
 
-`go get -u github.com/codesenberg/bombardier`
+`go install github.com/codesenberg/bombardier@latest`
 
 ## Usage
 ```


### PR DESCRIPTION
I get the following installing via the readme method
```
go get: installing executables with 'go get' in module mode is deprecated.
        Use 'go install pkg@version' instead.
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```