### PR TITLE
Allow HTTP redirects

### DIFF
--- a/args_parser.go
+++ b/args_parser.go
@@ -28,6 +28,7 @@ type kingpinParser struct {
 	latencies         bool
 	insecure          bool
 	disableKeepAlives bool
+	allowRedirects    bool
 	method            string
 	body              string
 	bodyFilePath      string
@@ -111,6 +112,10 @@ func newKingpinParser() argsParser {
 		"Disable HTTP keep-alive. For fasthttp use -H 'Connection: close'").
 		Short('a').
 		BoolVar(&kparser.disableKeepAlives)
+	app.Flag("allowRedirects",
+		"Allow the client to follow HTTP redirects").
+		Short('R').
+		BoolVar(&kparser.allowRedirects)
 
 	app.Flag("header", "HTTP headers to use(can be repeated)").
 		PlaceHolder("\"K: V\"").
@@ -226,6 +231,7 @@ func (k *kingpinParser) parse(args []string) (config, error) {
 		printLatencies:    k.latencies,
 		insecure:          k.insecure,
 		disableKeepAlives: k.disableKeepAlives,
+		allowRedirects:    k.allowRedirects,
 		rate:              k.rate.val,
 		clientType:        k.clientType,
 		printIntro:        pi,

--- a/args_parser_test.go
+++ b/args_parser_test.go
@@ -711,6 +711,27 @@ func TestArgsParsing(t *testing.T) {
 				format:        userDefinedTemplate("/path/to/tmpl.txt"),
 			},
 		},
+		{
+			[][]string{
+				{
+					programName,
+					"localhost:8080",
+					"-R",
+				},
+			},
+			config{
+				numConns:       defaultNumberOfConns,
+				timeout:        defaultTimeout,
+				headers:        new(headersList),
+				method:         "GET",
+				url:            "http://localhost:8080",
+				printIntro:     true,
+				printProgress:  true,
+				printResult:    true,
+				format:         knownFormat("plain-text"),
+				allowRedirects: true,
+			},
+		},
 	}
 	for _, e := range expectations {
 		for _, args := range e.in {

--- a/bombardier.go
+++ b/bombardier.go
@@ -132,6 +132,7 @@ func newBombardier(c config) (*bombardier, error) {
 		timeout:           c.timeout,
 		tlsConfig:         tlsConfig,
 		disableKeepAlives: c.disableKeepAlives,
+		allowRedirects:    c.allowRedirects,
 
 		headers:      c.headers,
 		url:          c.url,

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type config struct {
 	numConns                       uint64
 	numReqs                        *uint64
 	disableKeepAlives              bool
+	allowRedirects                 bool
 	duration                       *time.Duration
 	url, method, certPath, keyPath string
 	body, bodyFilePath             string


### PR DESCRIPTION
For some reason we want to test throughput with HTTP redirect enabled.
This PR adds a flag(default to false) to allow the client to follow HTTP redirects