### PR TITLE
clients: Fix request with headers set

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -78,10 +78,10 @@ func (c *fasthttpClient) do() (
 	// prepare the request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
-	req.Header.SetHost(c.host)
 	if c.headers != nil {
 		c.headers.CopyTo(&req.Header)
 	}
+	req.Header.SetHost(c.host)
 	req.SetRequestURI(c.requestURI)
 	req.Header.SetMethod(c.method)
 	req.URI().SetScheme(c.scheme)


### PR DESCRIPTION
bombardier was failing to connect to the server if custom headers were set. This happened because the `Host` header was being overwritten during request creation. By reordering the operations (first set the headers, then the Host header) we can avoid this problem.

Example problem:
```
$ go run . -H 'Content-Type: application/json' -m POST http://localhost:8000/anything -p r -t 1s -n 1
Statistics        Avg      Stdev        Max
  Reqs/sec      1372.12       0.00    1372.12
  Latency       10.00us     0.00us    10.00us
  HTTP codes:
    1xx - 0, 2xx - 0, 3xx - 0, 4xx - 0, 5xx - 0
    others - 1
  Errors:
    dial tcp: missing address - 1
  Throughput:       0.00/s
```