### PR TITLE
error_map: canonicalise error

### DIFF
--- a/error_map_test.go
+++ b/error_map_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -20,6 +21,24 @@ func TestErrorMapGet(t *testing.T) {
 	err := errors.New("get")
 	if c := m.get(err); c != 0 {
 		t.Error(c)
+	}
+}
+
+func TestCanonicalisedError(t *testing.T) {
+	m := newErrorMap()
+	for i := 0; i < 10; i++ {
+		m.add(fmt.Errorf("read tcp 10.10.0.62:%d->63.35.24.107:%d: read: connection reset by peer", 1000+i, 2000+i))
+	}
+	m.add(errors.New("tls timeout"))
+
+	e := errorsByFrequency{
+		{"connection reset by peer", 10},
+		{"tls timeout", 1},
+	}
+	if a := m.byFrequency(); !reflect.DeepEqual(a, e) {
+		t.Logf("Expected: %+v", e)
+		t.Logf("Got: %+v", a)
+		t.Fail()
 	}
 }
 


### PR DESCRIPTION
The changes canonicalise request errors so same kind of errors are grouped together.

For example the following errors are same kind but they are treated different because the ip/port in the messages are different. As they are considered different errors, the test result overloaded with these repeated errors and it requires scrolling many pages to find other useful info.

```
    read tcp 10.10.0.62:32774->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:43898->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:34816->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:43606->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:38474->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:33108->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:39948->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:43194->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:48982->63.35.24.107:443: read: connection reset by peer - 1
    read tcp 10.10.0.62:57552->63.35.24.107:443: read: connection reset by peer - 1
```