### PR TITLE
Fix --insecure when no certificate is passed

### DIFF
--- a/client_cert.go
+++ b/client_cert.go
@@ -22,22 +22,18 @@ func readClientCert(certPath, keyPath string) ([]tls.Certificate, error) {
 // generateTLSConfig - helper function to generate a TLS configuration based on
 // config
 func generateTLSConfig(c config) (*tls.Config, error) {
-	// Return nil, if no custom cert/key pair was provided.
-	// This assumes that the caller has validated that either both or none of
-	// the c.certPath and c.keyPath are set.
-	if c.certPath == "" && c.keyPath == "" {
-		return nil, nil
-	}
-	certs, err := readClientCert(c.certPath, c.keyPath)
-	if err != nil {
-		return nil, err
-	}
 	// Disable gas warning, because InsecureSkipVerify may be set to true
 	// for the purpose of testing
 	/* #nosec */
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: c.insecure,
-		Certificates:       certs,
+	}
+	if c.certPath != "" || c.keyPath != "" {
+		certs, err := readClientCert(c.certPath, c.keyPath)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = certs
 	}
 	return tlsConfig, nil
 }


### PR DESCRIPTION
Previously, `--insecure` had no effect when no client certificate was supplied. So it was impossible to use bombardier with self-signed or otherwise invalid server certificate.
